### PR TITLE
Remove netlify status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Flare Technical Documentation
 
 ![example workflow](https://github.com/flare-foundation/docs/actions/workflows/ci.yml/badge.svg)
-[![Netlify Status](https://api.netlify.com/api/v1/badges/1603e657-66b1-4125-816b-e6b86f62d589/deploy-status)](https://app.netlify.com/sites/flare-docs-previews/deploys)
 
 This is the source repository for the [Flare docs](https://docs.flare.network/) site.


### PR DESCRIPTION
docs are deployed to github pages. Netlify seems out-of-scope